### PR TITLE
키스토어 재생성

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -6,6 +6,15 @@ plugins {
     id("com.google.gms.google-services")
 }
 
+import java.util.Properties
+        import java.io.FileInputStream
+
+val keystoreProperties = Properties()
+val keystorePropertiesFile = rootProject.file("key.properties")
+if (keystorePropertiesFile.exists()) {
+    keystoreProperties.load(FileInputStream(keystorePropertiesFile))
+}
+
 android {
     namespace = "com.example.inventory_check"
     compileSdk = 35
@@ -33,10 +42,10 @@ android {
 
     signingConfigs {
         create("release") {
-            keyAlias = project.findProperty("MY_KEY_ALIAS") as String
-            keyPassword = project.findProperty("MY_KEY_PASSWORD") as String
-            storeFile = file(project.findProperty("MY_KEYSTORE_FILE") as String)
-            storePassword = project.findProperty("MY_KEYSTORE_PASSWORD") as String
+            keyAlias = keystoreProperties["MY_KEY_ALIAS"] as String
+            keyPassword = keystoreProperties["MY_KEY_PASSWORD"] as String
+            storeFile = file(keystoreProperties["MY_KEYSTORE_FILE"] as String)
+            storePassword = keystoreProperties["MY_KEYSTORE_PASSWORD"] as String
         }
     }
 

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,8 +1,4 @@
 org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
 android.enableJetifier=true
-MY_KEYSTORE_FILE=release-key.jks
-MY_KEYSTORE_PASSWORD=opop8520
-MY_KEY_ALIAS=release-key
-MY_KEY_PASSWORD=opop8520
 


### PR DESCRIPTION
## PR 설명
- 기존 노출 위험이 있던 keystore(`release-key.jks`)를 폐기하고 새 keystore를 생성했습니다.
- `key.properties` 파일을 통해 keystore 정보를 불러오도록 `app/build.gradle.kts` 수정.
- `.gitignore`에 `*.jks`, `key.properties`가 포함되어 있어 민감 정보는 저장소에 포함되지 않도록 처리했습니다.

---

## 구현 내용 요약
- 새로운 keystore `release-key.jks` 생성 및 프로젝트에 적용
- `android/key.properties` 추가 (gitignore 처리됨)
- `app/build.gradle.kts`에서 `keystoreProperties`를 로드해 signingConfigs 적용
- 구 버전 keystore 삭제 처리

---

## 관련 변경 사항
- `android/app/build.gradle.kts` : signingConfigs 수정
- `android/key.properties` : 새 keystore 정보 (gitignore 적용, 레포엔 미포함)
- `.gitignore` : keystore 및 key.properties 안전하게 무시 확인 완료

---

## 참고 사항
- Firebase App Distribution을 통한 배포 시 새 keystore 기반으로 빌드된 APK/AAB 사용 예정
- Google Play에 배포 이력은 없음 → 키 교체 절차 불필요

---

## 테스트 방법
- [x] `flutter build apk --release` 실행 후 정상적으로 빌드 완료 확인
- [x] Firebase App Distribution 업로드 테스트 진행
- [x] 앱 설치 및 실행 정상 동작 확인
